### PR TITLE
Set content mode and compression to animated view on macOS

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/airbnb/lottie-ios.git",
         "state": {
           "branch": null,
-          "revision": "246bab7ef72bad56abefb88e84a08871cecf9cb8",
-          "version": "3.4.0"
+          "revision": "4ca8023b820b7d5d5ae1e2637c046e3dab0f45d0",
+          "version": "3.4.2"
         }
       }
     ]

--- a/Sources/LottieUI/macOS/WrappedAnimationNSView.swift
+++ b/Sources/LottieUI/macOS/WrappedAnimationNSView.swift
@@ -14,7 +14,8 @@ public class WrappedAnimationNSView: NSView, WrappedAnimationProtocol {
     
     public init(animation: Lottie.Animation?, provider: AnimationImageProvider?) {
         let animationView = AnimationView(animation: animation, imageProvider: provider)
-        animationView.translatesAutoresizingMaskIntoConstraints = false
+        animationView.contentMode = .scaleAspectFit
+        
         self.animationView = animationView
         
         super.init(frame: .zero)
@@ -28,6 +29,8 @@ public class WrappedAnimationNSView: NSView, WrappedAnimationProtocol {
             animationView.centerXAnchor.constraint(equalTo: centerXAnchor),
             animationView.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
+        animationView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+        animationView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
     }
     
     @available(*, unavailable)
@@ -42,6 +45,7 @@ public class WrappedAnimationNSView: NSView, WrappedAnimationProtocol {
         self.animationView = AnimationView(animation: animation,
                                              imageProvider: imageProvider,
                                              configuration: .init(renderingEngine: renderingEngine))
+        animationView.contentMode = .scaleAspectFit
         animationView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(animationView)
         NSLayoutConstraint.activate([
@@ -52,6 +56,8 @@ public class WrappedAnimationNSView: NSView, WrappedAnimationProtocol {
             animationView.centerXAnchor.constraint(equalTo: centerXAnchor),
             animationView.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
+        animationView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+        animationView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
     }
 }
 

--- a/Sources/LottieUI/macOS/WrappedAnimationNSView.swift
+++ b/Sources/LottieUI/macOS/WrappedAnimationNSView.swift
@@ -17,6 +17,7 @@ public class WrappedAnimationNSView: NSView, WrappedAnimationProtocol {
         animationView.contentMode = .scaleAspectFit
         
         self.animationView = animationView
+        animationView.translatesAutoresizingMaskIntoConstraints = false
         
         super.init(frame: .zero)
       


### PR DESCRIPTION
Related to #3 

This pull request fixes a scaling issue with the `WrappedAnimationNSView`, which could lead to LottieView's animation on macOS to fail to scale to the setup `frame`:

```swift
LottieView("loading")
    .loopMode(.loop)
    .frame(width: 200, height: 200, alignment: .center)
    .background(Color.red)
```

### Version 1.3.0 (main branch)

![Gravação de Tela 2022-08-20 às 13 54 19](https://user-images.githubusercontent.com/23082132/185758163-e74bea21-6308-42fc-bd9d-bc77151af6a0.gif)

### After changes in this PR

![Gravação de Tela 2022-08-20 às 13 51 38](https://user-images.githubusercontent.com/23082132/185758216-f2a870ed-36d5-4656-b009-f794e7cd277a.gif)

